### PR TITLE
Suppress the ouput when using quiet option

### DIFF
--- a/helpers/auditshell_script.patch
+++ b/helpers/auditshell_script.patch
@@ -95,10 +95,12 @@ index 242b815..778fbbe 100644
  	getmaster();
 -	if (!qflg)
 +
-+	if ((!qflg) && (dflg == 1)){
-+		printf(_("Script started, file descriptor number is %s\n"), fname);
-+   }else{
++   if (!qflg) {
++	  if (dflg == 1){
++	  	printf(_("Script started, file descriptor number is %s\n"), fname);
++     }else{
  		printf(_("Script started, file is %s\n"), fname);
++     }
 +   }
 +
  	fixtty();
@@ -110,10 +112,12 @@ index 242b815..778fbbe 100644
  		tcsetattr(STDIN_FILENO, TCSADRAIN, &tt);
 -		if (!qflg)
 +
-+      if ((!qflg) && (dflg == 1)){
-+         printf(_("Script done, file descriptor number is %s\n"), fname);
-+      }else{
++      if (!qflg) {
++        if (dflg == 1){
++           printf(_("Script done, file descriptor number is %s\n"), fname);
++        }else{
  			printf(_("Script done, file is %s\n"), fname);
++        }
 +      }
 +
 +


### PR DESCRIPTION
if we use -q/--quiet option with a normal file as the timing file.
The command output will still show. The patch suppressed all output
when quiet option is enabled