### PR TITLE
Bugfix: Pressing "c" while in pause doesn't resume playback.

### DIFF
--- a/scriptreplay
+++ b/scriptreplay
@@ -137,7 +137,7 @@ sub main() {
 			$accel = 1 if $key =~ /=|n/i;
 			last REPLAY   if $key =~ /q|f/i;
 			if ($key =~ /s|p/i) {
-				while (ReadKey(0) =~ /c/i) { next; }
+				while (ReadKey(0) !~ /c/i) { next; }
 			}
 		}
 


### PR DESCRIPTION
Hi,

According to the documentation, pressing "c" should resume playback, but it's not working.
Because the while loop for pausing only breaks when the key not matches "c".
